### PR TITLE
feat: allow schema as an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var jsonschema2mk = function(options) {
 	this.Handlebars.registerHelper(this.Helper);
 	this.Handlebars.registerHelper(require('./helper_examples.js'));
 
-	this.load_partial_dir(__dirname + "/partials/"); 
+	this.load_partial_dir(__dirname + "/partials/");
 
 	this.data = {
 		schema: parseSchema(options),

--- a/index.js
+++ b/index.js
@@ -3,6 +3,17 @@
 const fs = require('fs');
 const path = require('path');
 
+function parseSchema(options) {
+	const { schema } = options;
+
+	if (schema && typeof schema === "object") {
+		return schema;
+	}
+
+	const schemaPath = schema || "schema.json";
+	return JSON.parse(fs.readFileSync(schemaPath));
+}
+
 var jsonschema2mk = function(options) {
 	var _this = this;
 
@@ -13,11 +24,10 @@ var jsonschema2mk = function(options) {
 	this.Handlebars.registerHelper(this.Helper);
 	this.Handlebars.registerHelper(require('./helper_examples.js'));
 
-	this.load_partial_dir(__dirname + "/partials/");
+	this.load_partial_dir(__dirname + "/partials/"); 
 
 	this.data = {
-		schema: JSON.parse(fs.readFileSync(
-				options.schema || "schema.json")),
+		schema: parseSchema(options),
 		argv: options,
 	};
 


### PR DESCRIPTION
## Description

I'm using `jsonschema2mk` as a library to auto-generate some documentation based on remote JSON schemas. So, my data flow is the following:

- I fetch the JSON schemas from a remote source.
- For each schema, I create a temp file 😢.
- I call `jsonschema2mk` with the temp file path.

However, I think that a small change could be useful for these cases: allowing schemas to be passed as objects.