### PR TITLE
fix: escape regexp

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -32,6 +32,12 @@ exports.escape = function(text) {
 	return new Handlebars.SafeString(result);
 };
 
+exports.escapeRegexp = function(text) {
+	if (typeof text === "undefined" || text === null) return "";
+	var result = text.toString().replace(/(\|)/g, "\\$1");
+	return new Handlebars.SafeString(result);
+}
+
 exports.json = function (string) {
 	var result = "```json\n"+
 		JSON.stringify(string, undefined, "    ")+"\n"+

--- a/partials/extra.md
+++ b/partials/extra.md
@@ -21,7 +21,7 @@
 **{{prefix_text}}Format:** {{jsoninline format}}{{br}}
 {{/if}}
 	{{~#if (isdefined pattern)~}}
-**{{prefix_text}}Pattern:** {{code pattern}}{{br}}
+**{{prefix_text}}Pattern:** `{{escapeRegexp pattern}}`{{br}}
 {{/if}}
 {{~/if}}
 {{~#if (or (is_type type "number") (is_type type "integer"))~}}

--- a/partials/extra.md
+++ b/partials/extra.md
@@ -21,7 +21,7 @@
 **{{prefix_text}}Format:** {{jsoninline format}}{{br}}
 {{/if}}
 	{{~#if (isdefined pattern)~}}
-**{{prefix_text}}Pattern:** `{{escapeRegexp pattern}}`{{br}}
+**{{prefix_text}}Pattern:** {{code (escapeRegexp pattern)}}{{br}}
 {{/if}}
 {{~/if}}
 {{~#if (or (is_type type "number") (is_type type "integer"))~}}

--- a/partials/extra_inline.md
+++ b/partials/extra_inline.md
@@ -6,7 +6,7 @@
 {{~#if (isdefined minLength)}}{{prefix_text}}Minimal Length: {{jsoninline minLength}}<br/>{{~/if}}
 {{~#if (isdefined maxLength)}}{{prefix_text}}Maximal Length: {{jsoninline maxLength}}<br/>{{~/if}}
 {{~#if (isdefined format)}}{{prefix_text}}Format: {{jsoninline format}}<br/>{{~/if}}
-{{~#if (isdefined pattern)}}{{prefix_text}}Pattern: `{{escapeRegexp pattern}}`<br/>{{~/if~}}
+{{~#if (isdefined pattern)}}{{prefix_text}}Pattern: {{code (escapeRegexp pattern)}}<br/>{{~/if~}}
 {{~#if (isdefined exclusiveMinimum)}}{{prefix_text}}Minimum (exclusive): {{jsoninline exclusiveMinimum}}<br/>{{~/if}}
 {{~#if (isdefined minimum)}}{{prefix_text}}Minimum: {{jsoninline minimum}}<br/>{{~/if}}
 {{~#if (isdefined exclusiveMaximum)}}{{prefix_text}}Maximum (exclusive): {{jsoninline exclusiveMaximum}}<br/>{{~/if}}

--- a/partials/extra_inline.md
+++ b/partials/extra_inline.md
@@ -6,7 +6,7 @@
 {{~#if (isdefined minLength)}}{{prefix_text}}Minimal Length: {{jsoninline minLength}}<br/>{{~/if}}
 {{~#if (isdefined maxLength)}}{{prefix_text}}Maximal Length: {{jsoninline maxLength}}<br/>{{~/if}}
 {{~#if (isdefined format)}}{{prefix_text}}Format: {{jsoninline format}}<br/>{{~/if}}
-{{~#if (isdefined pattern)}}{{prefix_text}}Pattern: `{{code pattern}}`<br/>{{~/if~}}
+{{~#if (isdefined pattern)}}{{prefix_text}}Pattern: `{{escapeRegexp pattern}}`<br/>{{~/if~}}
 {{~#if (isdefined exclusiveMinimum)}}{{prefix_text}}Minimum (exclusive): {{jsoninline exclusiveMinimum}}<br/>{{~/if}}
 {{~#if (isdefined minimum)}}{{prefix_text}}Minimum: {{jsoninline minimum}}<br/>{{~/if}}
 {{~#if (isdefined exclusiveMaximum)}}{{prefix_text}}Maximum (exclusive): {{jsoninline exclusiveMaximum}}<br/>{{~/if}}

--- a/partials/object.md
+++ b/partials/object.md
@@ -37,7 +37,7 @@
 **{{prefix_text}}Maximal Properties:** {{escape maxProperties}}{{br}}
 {{/if~}}
 {{#if (and (isdefined propertyNames) (isdefined propertyNames.pattern))}}
-**{{prefix_text}}Property Name Pattern:** `{{escapeRegexp propertyNames.pattern}}`{{br}}
+**{{prefix_text}}Property Name Pattern:** {{code (escapeRegexp propertyNames.pattern)}}{{br}}
 {{/if~}}
 {{#if (isdefined dependentRequired)}}
 {{#each dependentRequired}}

--- a/partials/object.md
+++ b/partials/object.md
@@ -37,7 +37,7 @@
 **{{prefix_text}}Maximal Properties:** {{escape maxProperties}}{{br}}
 {{/if~}}
 {{#if (and (isdefined propertyNames) (isdefined propertyNames.pattern))}}
-**{{prefix_text}}Property Name Pattern:** {{code propertyNames.pattern}}{{br}}
+**{{prefix_text}}Property Name Pattern:** `{{escapeRegexp propertyNames.pattern}}`{{br}}
 {{/if~}}
 {{#if (isdefined dependentRequired)}}
 {{#each dependentRequired}}

--- a/test/031-if.md
+++ b/test/031-if.md
@@ -19,7 +19,7 @@
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**postal\_code**||Pattern: ``[0-9]{5}(-[0-9]{4})?``<br/>||
+|**postal\_code**||Pattern: `[0-9]{5}(-[0-9]{4})?`<br/>||
 
 
 **OTHERWISE**
@@ -29,7 +29,7 @@
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**postal\_code**||Pattern: ``[A-Z][0-9][A-Z] [0-9][A-Z][0-9]``<br/>||
+|**postal\_code**||Pattern: `[A-Z][0-9][A-Z] [0-9][A-Z][0-9]`<br/>||
 
 
 **Example**

--- a/test/103-pattern-regex.json
+++ b/test/103-pattern-regex.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "title": "VPC Configuration",
+  "properties": {
+    "id": {
+      "type": "string",
+      "title": "VPC ID",
+      "pattern": "^vpc-([0-9a-f]{8}|[0-9a-f]{17})$",
+      "examples": ["vpc-1a2b3c4d"],
+      "description": "The identifier of the VPC"    
+    }
+  }
+}

--- a/test/103-pattern-regex.md
+++ b/test/103-pattern-regex.md
@@ -1,0 +1,17 @@
+# VPC Configuration
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**id**<br/>(VPC ID)|`string`|The identifier of the VPC<br/>Pattern: `^vpc-([0-9a-f]{8}\|[0-9a-f]{17})$`<br/>||
+
+**Example**
+
+```json
+{
+    "id": "vpc-1a2b3c4d"
+}
+```
+
+


### PR DESCRIPTION
## Description

Recently, I used this library with a problematic schema due to a pattern property that looks like: `^vpc-([0-9a-f]{8}|[0-9a-f]{17})$`. This pattern breaks the markdown table because of the pipe symbol `|`.

## Changes

- Added a new helper called `escapeRegexp` which will replace `|` with `\|`
- Prefer using \`{{escapeRegexp pattern}}\` over the `code` helper.